### PR TITLE
Added new literature for 2023 and 2024

### DIFF
--- a/MYabrv.bib
+++ b/MYabrv.bib
@@ -347,7 +347,7 @@
 @String{JSMRP = "J.\ Software Maintenance: Research and Practice"}
 @String{SCS = "J.\ Statistical Computation and Simulation"}
 @String{Software = "IEEE Software"}
-@String{SoSyM = "Software and System Modeling (SoSyM)"}
+@String{SoSyM = "Software and Systems Modeling (SoSyM)"}
 @String{SPE = "Software: Practice and Experience"}
 @String{SPIP = "Software Process: Improvement and Practice"}
 @String{SQJ = "Software Quality Journal (SQJ)"}

--- a/literature.bib
+++ b/literature.bib
@@ -180,6 +180,39 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 2024 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+@inproceedings{RKZA:MSR24,
+	author = {Randrianaina, Georges Aaron and Khelladi, Djamel Eddine and Zendra, Olivier and Acher, Mathieu},
+	title = {{Options Matter: Documenting and Fixing Non-Reproducible Builds in Highly-Configurable Systems}},
+	booktitle = MSR,
+	location = {Lisbon, Portugal},
+	pages = {1--11},
+	month = APR,
+	year = 2024,
+	url = {https://inria.hal.science/hal-04441579}
+}
+
+@misc{W:24,
+	author = {Wayne, Hillel},
+	title = {{The Hunt for the Missing Data Type}},
+	note = {Accessed: 2024-03-22},
+	year = 2024,
+	howpublished = {\url{https://www.hillelwayne.com/post/graph-types}}
+}
+
+@inproceedings{YWG:VaMoS24,
+	author = {Yaman, Kaan Berk and Wittler, Jan Willem and Gerking, Christopher},
+	title = {{Kfeature: Rendering the Kconfig System into Feature Models}},
+	booktitle = VaMoS20,
+	isbn = {9798400708770},
+	publisher = ACM,
+	address = NY,
+	doi = {10.1145/3634713.3634731},
+	pages = {134–138},
+	numpages = {5},
+	location = {Bern, Switzerland},
+	year = 2024
+}
+
 @inproceedings{HSO+:VaMoS24,
 	author = {He{\ss}, Tobias and Schmidt, Tim Jannik and Ostheimer, Lukas and Krieter, Sebastian and Th{\"u}m, Thomas},
 	title = {{UnWise: High T-Wise Coverage From Uniform Sampling}},
@@ -257,6 +290,115 @@
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 2023 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@techreport{AKS:TR23,
+	author = {Adamy, Rick and Kuiter, Elias and Saake, Gunter},
+	title = {{Exploiting Structure: A Survey and Analysis of Structures and Hardness Measures for Propositional Formulas}},
+	doi = {10.32388/7u1pfg},
+	month = SEP,
+	year = 2023,
+	institution = UniMagdeburg,
+	archiveprefix = {{Qeios}},
+	eprint = {7u1pfg}
+}
+
+@inproceedings{ALR+:VaMoS23,
+	author = {Acher, Mathieu and Lesoil, Luc and Randrianaina, Georges Aaron and T\"{e}rnava, Xhevahire and Zendra, Olivier},
+	title = {{A Call for Removing Variability}},
+	booktitle = VaMoS20,
+	publisher = ACM,
+	address = NY,
+	location = {Odense, Denmark},
+	pages = {82--84},
+	isbn = {9798400700019},
+	doi = {10.1145/3571788.3571801},
+	year = 2023,
+	numpages = 3
+}
+
+@inproceedings{BFW:SAT23,
+	author = {Biere, Armin and Froleyks, Nils and Wang, Wenxi},
+	title = {{CadiBack: Extracting Backbones with CaDiCaL}},
+	booktitle = SAT,
+	pages = {3:1--3:12},
+	series = {Leibniz International Proceedings in Informatics (LIPIcs)},
+	isbn = {978-3-95977-286-0},
+	issn = {1868-8969},
+	year = 2023,
+	volume = 271,
+	editor = {Mahajan, Meena and Slivovsky, Friedrich},
+	publisher = SchlossDagstuhl,
+	address = Dagstuhl,
+	doi = {10.4230/LIPIcs.SAT.2023.3}
+}
+
+@misc{C:23,
+	author = {Chastain, Michael Elizabeth},
+	title = {{Linux Kernel Makefiles}},
+	note = {Accessed: 2023-07-10},
+	year = 2023,
+	howpublished = {\url{https://www.kernel.org/doc/html/latest/kbuild/makefiles.html}}
+}
+
+@inproceedings{HBPF:SPLC23,
+	author = {Horcas, Jose-Miguel and Ballesteros, Joaquin and Pinto, M\'{o}nica and Fuentes, Lidia},
+	title = {{Elimination of Constraints for Parallel Analysis of Feature Models}},
+	booktitle = SPLC,
+	publisher = ACM,
+	pages = {99--110},
+	doi = {10.1145/3579027.3608981},
+	year = 2023
+}
+
+@article{K:SoSyM23,
+	author = {Kautz, Oliver},
+	title = {{The Complexities of the Satisfiability Checking Problems of Feature Diagram Sublanguages}},
+	journal = SoSyM,
+	publisher = Springer,
+	volume = 22,
+	number = 4,
+	pages = {1113--1129},
+	doi = {10.1007/s10270-022-01048-3},
+	year = 2023
+}
+
+@article{MPFB:JSS23,
+	author = {Munoz, Daniel-Jesus and Pinto, M\'{o}nica and Fuentes, Lidia and Batory, Don},
+	title = {{Transforming Numerical Feature Models into Propositional Formulas and the Universal Variability Language}},
+	journal = JSS,
+	publisher = Elsevier,
+	volume = 204,
+	articleno = 111770,
+	doi = {10.1016/j.jss.2023.111770},
+	month = OCT,
+	year = 2023
+}
+
+@inproceedings{MSS:SAT23,
+	author = {Masina, Gabriele and Spallitta, Giuseppe and Sebastiani, Roberto},
+	title = {{On CNF Conversion for Disjoint SAT Enumeration}},
+	booktitle = SAT,
+	pages = {15:1--15:16},
+	series = {Leibniz International Proceedings in Informatics (LIPIcs)},
+	isbn = {978-3-95977-286-0},
+	issn = {1868-8969},
+	year = 2023,
+	volume = 271,
+	editor = {Mahajan, Meena and Slivovsky, Friedrich},
+	publisher = SchlossDagstuhl,
+	address = Dagstuhl,
+	doi = {10.4230/LIPIcs.SAT.2023.15}
+}
+
+@inproceedings{UBB+:23,
+	author = {Urli, Simon and Bergel, Alexandre and Blay-Fornarino, Mireille and Collet, Philippe and Mosser, Sébastien},
+	title = {{A Visual Support for Decomposing Complex Feature Models}},
+	booktitle = VISSOFT,
+	pages = {76--85},
+	publisher = IEEE,
+	doi = {10.1109/VISSOFT.2015.7332417},
+	year = 2015
+}
 
 @article{SKH+:AMAI23,
 	author = {Sundermann, Chico and Kuiter, Elias and He{\ss}, Tobias and Raab, Heiko and Krieter, Sebastian and Th{\"{u}}m, Thomas},

--- a/literature.bib
+++ b/literature.bib
@@ -191,14 +191,6 @@
 	url = {https://inria.hal.science/hal-04441579}
 }
 
-@misc{W:24,
-	author = {Wayne, Hillel},
-	title = {{The Hunt for the Missing Data Type}},
-	note = {Accessed: 2024-03-22},
-	year = 2024,
-	howpublished = {\url{https://www.hillelwayne.com/post/graph-types}}
-}
-
 @inproceedings{YWG:VaMoS24,
 	author = {Yaman, Kaan Berk and Wittler, Jan Willem and Gerking, Christopher},
 	title = {{Kfeature: Rendering the Kconfig System into Feature Models}},
@@ -312,8 +304,7 @@
 	pages = {82--84},
 	isbn = {9798400700019},
 	doi = {10.1145/3571788.3571801},
-	year = 2023,
-	numpages = 3
+	year = 2023
 }
 
 @inproceedings{BFW:SAT23,
@@ -330,14 +321,6 @@
 	publisher = SchlossDagstuhl,
 	address = Dagstuhl,
 	doi = {10.4230/LIPIcs.SAT.2023.3}
-}
-
-@misc{C:23,
-	author = {Chastain, Michael Elizabeth},
-	title = {{Linux Kernel Makefiles}},
-	note = {Accessed: 2023-07-10},
-	year = 2023,
-	howpublished = {\url{https://www.kernel.org/doc/html/latest/kbuild/makefiles.html}}
 }
 
 @inproceedings{HBPF:SPLC23,
@@ -388,16 +371,6 @@
 	publisher = SchlossDagstuhl,
 	address = Dagstuhl,
 	doi = {10.4230/LIPIcs.SAT.2023.15}
-}
-
-@inproceedings{UBB+:23,
-	author = {Urli, Simon and Bergel, Alexandre and Blay-Fornarino, Mireille and Collet, Philippe and Mosser, Sébastien},
-	title = {{A Visual Support for Decomposing Complex Feature Models}},
-	booktitle = VISSOFT,
-	pages = {76--85},
-	publisher = IEEE,
-	doi = {10.1109/VISSOFT.2015.7332417},
-	year = 2015
 }
 
 @article{SKH+:AMAI23,
@@ -8874,6 +8847,16 @@ series = {SPLC '17}
 	editor = {Chiba, Shigeru and Tanter, Éric and Ernst, Erik and Hirschfeld, Robert},
 	doi = {10.1007/978-3-662-46734-3_1},
 	tt-tags = {Design by Contract,Aspect Orientation},
+	year = 2015
+}
+
+@inproceedings{UBB+:15,
+	author = {Urli, Simon and Bergel, Alexandre and Blay-Fornarino, Mireille and Collet, Philippe and Mosser, Sébastien},
+	title = {{A Visual Support for Decomposing Complex Feature Models}},
+	booktitle = VISSOFT,
+	pages = {76--85},
+	publisher = IEEE,
+	doi = {10.1109/VISSOFT.2015.7332417},
 	year = 2015
 }
 
@@ -25117,6 +25100,14 @@ Stories of successful software product line deployments often read like epic adv
 	year = 2018
 }
 
+@misc{KBuild,
+	author = {Chastain, Michael Elizabeth},
+	title = {{Linux Kernel Makefiles}},
+	note = {Accessed: 2023-07-10},
+	year = 2023,
+	howpublished = {\url{https://www.kernel.org/doc/html/latest/kbuild/makefiles.html}}
+}
+
 @misc{AHEAD,
 	author = {Don Batory},
 	title = {{AHEAD Tool Suite}},
@@ -25357,4 +25348,12 @@ Stories of successful software product line deployments often read like epic adv
 	howpublished = {\url{https://github.com/johnyf/tool_lists/blob/master/bdd.md}},
 	note = {Accessed: 2021-03-01},
 	year = 2020
+}
+
+@misc{missingdatatype,
+	author = {Wayne, Hillel},
+	title = {{The Hunt for the Missing Data Type}},
+	note = {Accessed: 2024-03-22},
+	year = 2024,
+	howpublished = {\url{https://www.hillelwayne.com/post/graph-types}}
 }


### PR DESCRIPTION
As it ~~drives me crazy~~ is inefficient to clone-and-own and review an extra.bib file for every new paper draft, I am currently working on integrating my own bibtex database into bibtags. It has about six hundred new entries (I removed most duplicates, although there may be some left). I am not sure how to best go about this, so I'll just start with the latest years, where the entries are probably most relevant to the group. Maybe we can just review and merge these in batches.

Alternatively, I can also keep my additional bibtex database separate and not integrate it. However, I am reviewing all entries anyways, so I might as well merge them here over the next few weeks/months. Thoughts?

(Also, please check the long form of SoSyM.)