### PR TITLE
Continuous integration for compiling literature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,6 @@ jobs:
     - name: Compile literature
       uses: xu-cheng/texlive-action@v2
       with:
-        scheme: small
+        scheme: full
         run: |
           ./test.sh compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test literature
 
 on:
   push:
-    branches: [ "ek" ]
+    branches: [ '**' ]
   pull_request:
-    branches: [ "ek" ]
+    branches: [ '**' ]
 
 jobs:
   test:
@@ -45,5 +45,6 @@ jobs:
     - name: Archive literature
       uses: actions/upload-artifact@v4
       with:
-        name: test_latex
-        path: test_latex
+        name: PDF
+        path: test_latex/pdf
+        retention-days: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Compile Literature
+name: Test literature
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ "ek" ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     strategy:
@@ -42,3 +42,8 @@ jobs:
         run: |
           tlmgr install csquotes
           ./test.sh compile
+    - name: Archive literature
+      uses: actions/upload-artifact@v4
+      with:
+        name: test_latex
+        path: test_latex

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
     - name: Compile literature
       uses: xu-cheng/texlive-action@v2
       with:
-        scheme: full
+        scheme: small
         run: |
+          tlmgr install csquotes
           ./test.sh compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Compile Literature
+
+on:
+  push:
+    branches: [ "ek" ]
+  pull_request:
+    branches: [ "ek" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Compile Literature
+      run: |
+        ./test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Compile Literature
+    - name: Check literature
+      run: |
+        ./test.sh check_integrity
+    - name: Clean literature
+      run: |
+        ./test.sh create_cleaned_literature
+    - name: Compile literature
       uses: xu-cheng/texlive-action@v2
       with:
         scheme: small
         run: |
-          ./test.sh
+          ./test.sh compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ name: Test literature
 on:
   push:
     branches: [ '**' ]
-  pull_request:
-    branches: [ '**' ]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,8 @@ jobs:
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Compile Literature
-      run: |
-        ./test.sh
+      uses: xu-cheng/texlive-action@v2
+      with:
+        scheme: small
+        run: |
+          ./test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,10 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,13 +42,15 @@ jobs:
         run: |
           tlmgr install csquotes
           ./test.sh compile
-    - name: Archive literature
+    - name: Archive logs
       uses: actions/upload-artifact@v4
       with:
         name: Logs
         path: test_latex/log
         retention-days: 5
+    - name: Archive PDFs
+      uses: actions/upload-artifact@v4
       with:
-        name: PDF
+        name: PDFs
         path: test_latex/pdf
         retention-days: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,10 @@ jobs:
     - name: Archive literature
       uses: actions/upload-artifact@v4
       with:
+        name: Logs
+        path: test_latex/log
+        retention-days: 5
+      with:
         name: PDF
         path: test_latex/pdf
         retention-days: 5

--- a/bibtex-ignore.txt
+++ b/bibtex-ignore.txt
@@ -1,0 +1,3 @@
+Warning--empty publisher in DGT:EMSE21
+Warning--can't use both volume and number fields in LMY:AAAI21
+Warning--can't use both volume and number fields in DPV:AAAI20

--- a/bibtex-ignore.txt
+++ b/bibtex-ignore.txt
@@ -1,3 +1,2 @@
-Warning--empty publisher in DGT:EMSE21
 Warning--can't use both volume and number fields in LMY:AAAI21
 Warning--can't use both volume and number fields in DPV:AAAI20

--- a/bibtex-ignore.txt
+++ b/bibtex-ignore.txt
@@ -1,2 +1,3 @@
+Warning--empty publisher in DGT:EMSE21
 Warning--can't use both volume and number fields in LMY:AAAI21
 Warning--can't use both volume and number fields in DPV:AAAI20

--- a/test.sh
+++ b/test.sh
@@ -110,13 +110,13 @@ run_bibtex () {
 		cat bibtex_$1_$2.log | grep -v "(There were" | grep -Fxv -f ../bibtex-ignore.txt > tmp; mv tmp bibtex_$1_$2.log
 		if [ -s bibtex_$1_$2.log ]; then
 			echo -e "${RED}fail${NOCOLOR}" >&2
-			cat bibtex_$1_$2.log
+			cat bibtex_$1_$2.log >&2
 			exit 1
 		fi
 		echo -e "${GREEN}OK${NOCOLOR}"
 	else
 		echo -e "${RED}fail${NOCOLOR}" >&2
-		cat bibtex_$1_$2.log
+		cat bibtex_$1_$2.log >&2
 		exit 1
 	fi
 }

--- a/test.sh
+++ b/test.sh
@@ -107,8 +107,13 @@ run_biber () {
 run_bibtex () {
 	echo -e -n "${GREEN}run $2 bibtex for $1...${NOCOLOR}"
 	if bibtex -terse $1 > bibtex_$1_$2.log ; then
+		cat bibtex_$1_$2.log | grep -v "(There were" | grep -Fxv -f ../bibtex-ignore.txt > tmp; mv tmp bibtex_$1_$2.log
+		if [ -s bibtex_$1_$2.log ]; then
+			echo -e "${RED}fail${NOCOLOR}" >&2
+			cat bibtex_$1_$2.log
+			exit 1
+		fi
 		echo -e "${GREEN}OK${NOCOLOR}"
-		cat bibtex_$1_$2.log
 	else
 		echo -e "${RED}fail${NOCOLOR}" >&2
 		cat bibtex_$1_$2.log

--- a/test.sh
+++ b/test.sh
@@ -167,13 +167,13 @@ change_into_latex_dir
 delete_auxiliary_files
 
 default() {
-    check_integrity
+	check_integrity
 	create_cleaned_literature
 	compile
 }
 
 if [[ -z "$*" ]]; then
-    default
+	default
 else
-    "$@"
+	"$@"
 fi

--- a/test.sh
+++ b/test.sh
@@ -150,19 +150,30 @@ compile_bibtex () {
 	run_pdflatex $1 3 ""
 }
 
+compile() {
+	compile_bibtex short-natbib
+	compile_bibtex short-natibib-clean
+	compile_biber short-biblatex
+	compile_biber short-biblatex-clean
+	compile_biber abrv-biblatex
+
+	move_output_files pdf
+	move_output_files log
+	delete_auxiliary_files
+}
+
 ## Main script
 change_into_latex_dir
 delete_auxiliary_files
 
-check_integrity
-create_cleaned_literature
+default() {
+    check_integrity
+	create_cleaned_literature
+	compile
+}
 
-compile_bibtex short-natbib
-compile_bibtex short-natibib-clean
-compile_biber short-biblatex
-compile_biber short-biblatex-clean
-compile_biber abrv-biblatex
-
-move_output_files pdf
-move_output_files log
-delete_auxiliary_files
+if [[ -z "$*" ]]; then
+    default
+else
+    "$@"
+fi


### PR DESCRIPTION
Implements a GitHub action for automatically checking, cleaning, and compiling the literature as PDF. This will be triggered on any commit on any branch. It takes about five minutes and will fail if ./test.sh returns a non-zero exit code (which will probably trigger an email to the committer). The produced PDF files are archived for five days and are available for download (e.g., [here](https://github.com/SoftVarE-Group/BibTags/actions/runs/9793755440)). Commits are not rejected, this is just additional information.