### PR TITLE
Updated SRH+:TOSEM24 for official publication

### DIFF
--- a/literature.bib
+++ b/literature.bib
@@ -224,17 +224,6 @@
 	ek-tags = {reproducibility},
 }
 
-@article{SRH+:TOSEM24,
-	author = {Sundermann, Chico and Raab, Heiko and Heß, Tobias and Th{\"{u}}m, Thomas and Schaefer, Ina},
-	title = {{Reusing d-DNNFs for Efficient Feature-Model Counting}},
-	publisher = ACM,
-	address = NY,
-	journal = TOSEM,
-	year = 2024,
-	typo3Tags = {FMCounting},
-	note = {To appear}
-}
-
 @inproceedings{HOB+:MODEVAR24,
 	author = {He{\ss}, Tobias and Ostheimer, Lukas and Betz, Tobias and Karrer, Simon and Schmidt, Tim Jannik and Coquet, Pierre and Semmler, Sean and Th{\"u}m, Thomas},
 	title = {{variability.dev: Towards an Online Toolbox for Feature Modeling}},
@@ -312,6 +301,18 @@
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 2024 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@article{SRH+:TOSEM24,
+	author = {Sundermann, Chico and Raab, Heiko and Heß, Tobias and Th{\"{u}}m, Thomas and Schaefer, Ina},
+	title = {{Reusing d-DNNFs for Efficient Feature-Model Counting}},
+	publisher = ACM,
+	address = NY,
+	journal = TOSEM,
+	month = NOV,
+	year = 2024,
+	doi = {10.1145/3680465},
+	typo3Tags = {FMCounting}
+}
 
 @article{BRSK:JSS24,
   author       = {Alexander Boll and Pooja Rani and Alexander Schulthei{\ss} and Timo Kehrer},

--- a/literature.bib
+++ b/literature.bib
@@ -303,11 +303,15 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 2024 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 @article{SRH+:TOSEM24,
-	author = {Sundermann, Chico and Raab, Heiko and Heß, Tobias and Th{\"{u}}m, Thomas and Schaefer, Ina},
+	author = {Sundermann, Chico and Raab, Heiko and He{\ss{}}, Tobias and Th{\"{u}}m, Thomas and Schaefer, Ina},
 	title = {{Reusing d-DNNFs for Efficient Feature-Model Counting}},
 	publisher = ACM,
 	address = NY,
 	journal = TOSEM,
+	volume = {33},
+	number = {8},
+	articleno = {208},
+	numpages = {32},
 	month = NOV,
 	year = 2024,
 	doi = {10.1145/3680465},


### PR DESCRIPTION
TOSEM paper is now officially published: https://dl.acm.org/doi/10.1145/3680465