### PR TITLE
clean-to.sh: more platform independent shebang

### DIFF
--- a/clean-to.sh
+++ b/clean-to.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 java -cp mibtex/mibtex-cleaner.jar de.mibtex.BibtexCleaner "literature.bib" -o "$1/literature-cleaned.bib" "${@:2}"
 cp MYabrv.bib $1
 cp MYshort.bib $1


### PR DESCRIPTION
On NixOS, `bash` is not in `/bin`. It seems this also applies to some other OS. This solution should be more robust and be a non-breaking change.

Solution is from [here](https://discourse.nixos.org/t/shebang-locations/28992/2).